### PR TITLE
Fixed a bug where the navigation menu was not loaded properly

### DIFF
--- a/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.html
+++ b/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.html
@@ -1,5 +1,5 @@
-<div class="menu" role="navigation"> 
-    <ul data-bind="template: { name: 'navigation-item-template', foreach: navigationItems, afterRender: slideChildsUp }" />
+<div class="menu"  role="navigation"> 
+    <ul id="navigationMenu" data-bind="template: { name: 'navigation-item-template', foreach: navigationItems, afterRender: slideChildsUp }" />
 </div>
 <script id="navigation-item-template" type="text/html">
     <li class="menu_navigation_arrow_down">

--- a/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.html
+++ b/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.html
@@ -3,8 +3,8 @@
 </div>
 <script id="navigation-item-template" type="text/html">
     <li class="menu_navigation_arrow_down">
-        <h3 data-bind="click: $parent.mainItemClick">
-            <span data-bind="text: Title, click: $parent.mainItemClick"></span>
+        <h3 data-bind="event:{click: function(data,event){$parent.mainItemClick(data,event)}}">
+            <span data-bind="text: Title, event:{click: function(data,event){$parent.mainItemClick(data,event)}} "></span>
         </h3>
         <ul data-bind="template: { name: 'navigation-sub-item-template', foreach: ChildPages}"></ul>
     </li>

--- a/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
+++ b/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
@@ -2,6 +2,7 @@
 import ko = require("knockout");
 import jquery = require("jquery");
 import cms = require("app/infrastructure");
+import crossroads = require("crossroads");
 export var template: string = require("text!./navigation.html");
 
 export class viewModel extends cms.infrastructure.baseViewModel {
@@ -16,6 +17,12 @@ export class viewModel extends cms.infrastructure.baseViewModel {
         //}, this, 'menuGroupId');
         this.route = params.route;
         this.loadSideMenu(2);
+
+        crossroads.routed.add(function (request, data) {
+            console.log(request);
+            console.log(data.route + ' - ' + data.params + ' - ' + data.isFirst);
+            $("#navigationMenu > li").each((n, e) => { viewModel.slideChildsUpInternal(e)});
+        });
     }
 
     public fetchNavigationData(userRightId: number, success: (result: MenuItem[]) => void): any {
@@ -53,19 +60,37 @@ export class viewModel extends cms.infrastructure.baseViewModel {
         event.stopPropagation();
     }
 
-    slideChildsUp(elements) {
-        if (elements != null) {
-            $(elements[1]).children("ul").slideUp();
-            $(elements[1]).removeClass("menu_navigation_arrow_down");
-            $(elements[1]).addClass("menu_navigation_arrow_up");
+    public slideChildsUp(elements) {
+        viewModel.slideChildsUpInternal(elements[1]);
+    }
 
-            ko.contextFor(elements[1]).$data.ChildPages.forEach(function (v) {
+    public static slideChildsUpInternal(element) {
+        var slideUpNotRequired: boolean = false;
+        if (element != null) {
+            //$(element).children("ul").each((i, e : any) => {
+
+            //    ko.contextFor(e).$data.ChildPages.foreach(function (v) {
+            //        if (v.Url.indexOf(window.location.hash) != -1) {
+            //            slideUpNotRequired = true;
+            //        }
+            //    });
+
+            //    if (!slideUpNotRequired) {
+            //        e.slideUp();
+            //    }
+            //});
+
+            $(element).children("ul").slideUp();
+            $(element).removeClass("menu_navigation_arrow_down");
+            $(element).addClass("menu_navigation_arrow_up");
+
+            ko.contextFor(element).$data.ChildPages.forEach(function (v) {
                 if (v.Url.indexOf(window.location.hash) != -1) {
-                    $(elements[1]).children("ul").slideDown();
-                    $(elements[1]).removeClass("menu_navigation_arrow_up");
-                    $(elements[1]).addClass("menu_navigation_arrow_down");
+                    $(element).children("ul").slideDown();
+                    $(element).removeClass("menu_navigation_arrow_up");
+                    $(element).addClass("menu_navigation_arrow_down");
 
-                    $(elements[1]).children("ul").children("li").each(function (index) {
+                    $(element).children("ul").children("li").each(function (index) {
                         if (ko.contextFor(this).$data.Url.indexOf(window.location.hash) != -1) {
                             $(this).addClass("menu_navigation_highlight");
                         }
@@ -77,6 +102,9 @@ export class viewModel extends cms.infrastructure.baseViewModel {
             });
         };
     }
+
+
+
 
     getUserRightId(): number {
         var userRightId: number;

--- a/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
+++ b/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
@@ -56,13 +56,14 @@ export class viewModel extends cms.infrastructure.baseViewModel {
     slideChildsUp(elements) {
         if (elements != null) {
             $(elements[1]).children("ul").slideUp();
+            $(elements[1]).removeClass("menu_navigation_arrow_down");
             $(elements[1]).addClass("menu_navigation_arrow_up");
 
             ko.contextFor(elements[1]).$data.ChildPages.forEach(function (v) {
                 if (v.Url.indexOf(window.location.hash) != -1) {
                     $(elements[1]).children("ul").slideDown();
-                    $(event.target).parent().removeClass("menu_navigation_arrow_up");
-                    $(event.target).parent().addClass("menu_navigation_arrow_down");
+                    $(elements[1]).removeClass("menu_navigation_arrow_up");
+                    $(elements[1]).addClass("menu_navigation_arrow_down");
 
                     $(elements[1]).children("ul").children("li").each(function (index) {
                         if (ko.contextFor(this).$data.Url.indexOf(window.location.hash) != -1) {

--- a/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
+++ b/src/XOMNI.CMS.FrontEnd/src/components/navigation/navigation.ts
@@ -67,18 +67,6 @@ export class viewModel extends cms.infrastructure.baseViewModel {
     public static slideChildsUpInternal(element) {
         var slideUpNotRequired: boolean = false;
         if (element != null) {
-            //$(element).children("ul").each((i, e : any) => {
-
-            //    ko.contextFor(e).$data.ChildPages.foreach(function (v) {
-            //        if (v.Url.indexOf(window.location.hash) != -1) {
-            //            slideUpNotRequired = true;
-            //        }
-            //    });
-
-            //    if (!slideUpNotRequired) {
-            //        e.slideUp();
-            //    }
-            //});
 
             $(element).children("ul").slideUp();
             $(element).removeClass("menu_navigation_arrow_down");


### PR DESCRIPTION
When the active category of the navigation menu was slided down, the arrow that should be looking down was directed to right. Now its looking to bottom direction properly.